### PR TITLE
feat(#14): 恢復 newsletter 訂閱 UI 並串接 Buttondown

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,19 @@
 
   <div class="gradient-divider"></div>
 
+  <section class="section">
+    <div class="container">
+      <div class="newsletter-section fade-in">
+        <h2 class="newsletter-title"><i class="ph ph-envelope-simple"></i> <span data-i18n="newsletter.title">設計筆記</span></h2>
+        <p class="newsletter-desc" data-i18n="newsletter.desc">不定期分享字型設計思考、工具開發心得，以及創作過程中的發現。</p>
+        <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/erikyin" method="post" target="_blank">
+          <input type="email" name="email" placeholder="your@email.com" required>
+          <button type="submit"><i class="ph ph-paper-plane-tilt"></i> <span data-i18n="newsletter.btn">訂閱</span></button>
+        </form>
+        <p class="newsletter-privacy" data-i18n="newsletter.privacy">不會寄垃圾信，隨時可以退訂。</p>
+      </div>
+    </div>
+  </section>
 
   <div id="site-footer"></div>
 

--- a/writing-post.html
+++ b/writing-post.html
@@ -47,6 +47,15 @@
         <div class="article-author-desc" data-i18n="author.desc">字型設計師、工具開發者。用工程思維做字，用設計思維寫程式。</div>
       </div>
     </div>
+    <div class="newsletter-section fade-in">
+      <h2 class="newsletter-title"><i class="ph ph-envelope-simple"></i> <span data-i18n="newsletter.title">設計筆記</span></h2>
+      <p class="newsletter-desc" data-i18n="newsletter.desc">不定期分享字型設計思考、工具開發心得，以及創作過程中的發現。</p>
+      <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/erikyin" method="post" target="_blank">
+        <input type="email" name="email" placeholder="your@email.com" required>
+        <button type="submit"><i class="ph ph-paper-plane-tilt"></i> <span data-i18n="newsletter.btn">訂閱</span></button>
+      </form>
+      <p class="newsletter-privacy" data-i18n="newsletter.privacy">不會寄垃圾信，隨時可以退訂。</p>
+    </div>
     <nav class="article-nav fade-in" id="article-nav"></nav>
   </div>
 

--- a/writing.html
+++ b/writing.html
@@ -29,6 +29,15 @@
 
     <div class="essays-list" id="essays-list"></div>
 
+    <div class="newsletter-section fade-in">
+      <h2 class="newsletter-title"><i class="ph ph-envelope-simple"></i> <span data-i18n="newsletter.title">設計筆記</span></h2>
+      <p class="newsletter-desc" data-i18n="newsletter.desc">不定期分享字型設計思考、工具開發心得，以及創作過程中的發現。</p>
+      <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/erikyin" method="post" target="_blank">
+        <input type="email" name="email" placeholder="your@email.com" required>
+        <button type="submit"><i class="ph ph-paper-plane-tilt"></i> <span data-i18n="newsletter.btn">訂閱</span></button>
+      </form>
+      <p class="newsletter-privacy" data-i18n="newsletter.privacy">不會寄垃圾信，隨時可以退訂。</p>
+    </div>
 
   </div>
 


### PR DESCRIPTION
## Summary
- 恢復 #12 redesign 中移除的 newsletter section 到首頁、隨筆列表、文章頁
- 串接 Buttondown embed-subscribe 表單（HTML POST，零 JS 依賴）
- 文章頁新增 newsletter 區塊（作者資訊後、前後篇導覽前）

## Test plan
- [ ] 首頁 newsletter 卡片寬度正常（受 `.container` max-width 限制）
- [ ] 隨筆列表頁 newsletter 顯示正常
- [ ] 文章頁 newsletter 顯示在作者資訊與導覽之間
- [ ] 實際填寫 email 測試訂閱流程（新分頁開啟 Buttondown 確認頁）
- [ ] 雙語切換正常（中/英文字串）
- [ ] 行動版排版正常（表單垂直堆疊）

closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)