### PR TITLE
fix: 改用 CSS @keyframes 動畫修復 fade-in 不播放問題

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -126,7 +126,6 @@ var fadeObserver = null;
 
 function initFadeIn() {
   document.documentElement.classList.add('js-fade-ready');
-  void document.documentElement.offsetHeight; // force reflow to establish opacity:0
 
   fadeObserver = new IntersectionObserver(function(entries) {
     entries.forEach(function(e) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -104,8 +104,9 @@ body {
 .see-all { display: inline-flex; align-items: center; gap: 0.4rem; font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-secondary); text-decoration: none; margin-top: var(--space-lg); padding: 0.4rem 0; border-bottom: 1px solid var(--border); transition: color 0.2s, border-color 0.2s; letter-spacing: 0.03em; }
 .see-all:hover { color: var(--text); border-color: var(--text); text-decoration: none; }
 
-.js-fade-ready .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.6s ease, transform 0.6s ease; }
-.js-fade-ready .fade-in.visible { opacity: 1; transform: translateY(0); }
+@keyframes fadeInUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+.js-fade-ready .fade-in { opacity: 0; transform: translateY(16px); }
+.js-fade-ready .fade-in.visible { animation: fadeInUp 0.6s ease forwards; }
 
 .lang-notice { display: none; padding: var(--space-sm) var(--space-md); margin-top: var(--space-md); background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; color: var(--text-secondary); font-size: 0.9rem; line-height: 1.8; }
 [data-lang="en"] .lang-notice { display: block; }


### PR DESCRIPTION
## Summary
- 將 fade-in 從 CSS transition 改為 `@keyframes` animation，解決動畫不播放的問題
- 移除不再需要的 `offsetHeight` reflow hack
- 根因：IntersectionObserver 在 paint 前觸發，transition 需要先 paint 初始值才能動畫；`@keyframes` 自帶 from/to 狀態，不受此限制

## Test plan
- [ ] Chrome / Arc 測試：頁面間導航不閃爍
- [ ] 首次載入：fade-in 動畫正常播放（元素從下方淡入）
- [ ] 捲動：below-fold 元素在進入視口時播放動畫
- [ ] 停用 JS：所有內容仍可見（漸進增強）

🤖 Generated with [Claude Code](https://claude.com/claude-code)