### PR TITLE
feat: 首頁改善 — Glyph Field 色彩、區塊排序、行動版 Header

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -27,12 +27,12 @@ function toggleTheme() {
 }
 
 function updateThemeIcon() {
-  var icon = document.querySelector('.theme-icon');
-  if (icon) {
-    icon.className = document.documentElement.getAttribute('data-theme') === 'dark'
-      ? 'ph ph-sun theme-icon'
-      : 'ph ph-moon theme-icon';
-  }
+  var cls = document.documentElement.getAttribute('data-theme') === 'dark'
+    ? 'ph ph-sun theme-icon'
+    : 'ph ph-moon theme-icon';
+  document.querySelectorAll('.theme-icon').forEach(function(icon) {
+    icon.className = cls;
+  });
 }
 
 // ===== Language =====
@@ -151,12 +151,45 @@ function observeNewFadeIns(container) {
 // ===== Mobile Nav =====
 
 function initMobileNav() {
-  document.querySelectorAll('.nav-links a').forEach(function(a) {
+  var nav = document.querySelector('.nav-links');
+  if (!nav) return;
+
+  // Close dropdown on link click
+  nav.querySelectorAll('a').forEach(function(a) {
     a.addEventListener('click', function() {
-      var nav = document.querySelector('.nav-links');
-      if (nav) nav.classList.remove('show');
+      nav.classList.remove('show');
     });
   });
+
+  // Inject support + theme toggle into mobile dropdown
+  if (window.matchMedia('(max-width: 768px)').matches) {
+    var actions = document.createElement('div');
+    actions.className = 'mobile-actions';
+
+    var supportLink = document.createElement('a');
+    supportLink.href = 'about.html#support';
+    supportLink.className = 'header-btn header-btn-support';
+    supportLink.setAttribute('aria-label', 'Support');
+    supportLink.title = 'Support';
+    var heartIcon = document.createElement('i');
+    heartIcon.className = 'ph ph-heart';
+    supportLink.appendChild(heartIcon);
+
+    var themeBtn = document.createElement('button');
+    themeBtn.className = 'header-btn header-btn-theme';
+    themeBtn.setAttribute('aria-label', '\u5207\u63DB\u6DF1\u6DFA\u8272\u6A21\u5F0F');
+    themeBtn.addEventListener('click', function() { toggleTheme(); });
+    var themeIcon = document.createElement('i');
+    themeIcon.className = 'ph ph-moon theme-icon';
+    themeBtn.appendChild(themeIcon);
+
+    actions.appendChild(supportLink);
+    actions.appendChild(themeBtn);
+    nav.appendChild(actions);
+
+    // Sync icon state with current theme
+    updateThemeIcon();
+  }
 }
 
 // ===== Markdown Rendering (privacy/terms) =====

--- a/assets/style.css
+++ b/assets/style.css
@@ -141,10 +141,11 @@ body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height
 .hero-accent { height: 3px; width: 8rem; margin: var(--space-md) 0 var(--space-lg); border-radius: 2px; background: linear-gradient(135deg, var(--gradient-brand)); }
 .hero-visual { display: flex; justify-content: center; align-items: center; }
 .glyph-field { width: 280px; height: 280px; display: grid; grid-template-columns: repeat(var(--glyph-cols, 17), 1fr); grid-template-rows: repeat(var(--glyph-cols, 17), 1fr); gap: 0; overflow: hidden; }
-.glyph-field span { display: flex; align-items: center; justify-content: center; font-family: "JetBrains Mono", "Noto Sans TC", sans-serif; font-size: 0.85rem; line-height: 1; color: var(--text); opacity: 0.08; transition: opacity 0.6s ease; overflow: hidden; }
+.glyph-field span { display: flex; align-items: center; justify-content: center; font-family: "JetBrains Mono", "Noto Sans TC", sans-serif; font-size: 0.85rem; line-height: 1; color: var(--text); opacity: 0.08; transition: opacity 0.6s ease, color 0.4s ease; overflow: hidden; }
 .glyph-field span.glyph-cjk { font-size: 0.75rem; }
 .glyph-field span.glyph-latin { font-size: 0.9rem; }
 .glyph-field span.glyph-square { font-size: 0.65rem; }
+#index-essays, #index-works { padding-bottom: var(--space-sm); }
 
 /* ===== 8. About ===== */
 .about-hero { padding: var(--space-2xl) 0; display: flex; flex-direction: column; align-items: center; text-align: center; }
@@ -320,11 +321,16 @@ body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height
 
 /* ===== 17. Responsive ===== */
 @media (max-width: 768px) {
-  /* Header */
-  .nav-toggle { display: flex; }
-  .nav-links { display: none; position: absolute; top: 3.5rem; left: 0; right: 0; background: var(--bg); border-bottom: 1px solid var(--border-light); flex-direction: column; padding: var(--space-sm) var(--space-md); }
+  /* Header — mobile: logo ... EN ☰ */
+  .nav-toggle { display: flex; order: 3; margin-left: 0.5rem; }
+  .nav-links { display: none; position: absolute; top: 3.5rem; left: 0; right: 0; background: var(--bg); border-bottom: 1px solid var(--border-light); flex-direction: column; padding: var(--space-sm) var(--space-md); z-index: 100; }
   .nav-links.show { display: flex; }
   .header-inner { position: relative; }
+  .header-actions { margin-left: auto; order: 2; }
+  .header-actions .header-btn-support { display: none; }
+  .header-actions .header-btn-theme { display: none; }
+  .nav-links .mobile-actions { display: flex; align-items: center; gap: 0.5rem; padding-top: var(--space-sm); margin-top: var(--space-xs); border-top: 1px solid var(--border-light); }
+  .nav-links .mobile-actions .header-btn { display: flex; }
 
   /* Index hero */
   .hero-inner { grid-template-columns: 1fr; text-align: center; }

--- a/data/ui.js
+++ b/data/ui.js
@@ -181,7 +181,7 @@ window.UI_COMPONENTS = {
         '<div class="header-actions">' +
           '<a href="about.html#support" class="header-btn header-btn-support" aria-label="Support" title="Support"><i class="ph ph-heart"></i></a>' +
           '<button class="header-btn lang-btn" onclick="toggleLang()" aria-label="\u5207\u63DB\u8A9E\u8A00"><span class="lang-label">EN</span></button>' +
-          '<button class="header-btn" onclick="toggleTheme()" aria-label="\u5207\u63DB\u6DF1\u6DFA\u8272\u6A21\u5F0F"><i class="ph ph-moon theme-icon"></i></button>' +
+          '<button class="header-btn header-btn-theme" onclick="toggleTheme()" aria-label="\u5207\u63DB\u6DF1\u6DFA\u8272\u6A21\u5F0F"><i class="ph ph-moon theme-icon"></i></button>' +
         '</div>' +
       '</div>' +
     '</header>';

--- a/index.html
+++ b/index.html
@@ -62,23 +62,23 @@
 
   <div class="gradient-divider"></div>
 
-  <!-- Works -->
-  <section class="section">
-    <div class="container">
-      <div class="section-label fade-in">Works</div>
-      <div class="works-grid" id="index-works"></div>
-      <a href="works.html" class="see-all fade-in" id="works-see-all"></a>
-    </div>
-  </section>
-
-  <div class="gradient-divider"></div>
-
   <!-- Writing -->
   <section class="section">
     <div class="container">
       <div class="section-label fade-in">Writing</div>
       <div class="essays-list" id="index-essays"></div>
       <a href="writing.html" class="see-all fade-in" id="writing-see-all"></a>
+    </div>
+  </section>
+
+  <div class="gradient-divider"></div>
+
+  <!-- Works -->
+  <section class="section">
+    <div class="container">
+      <div class="section-label fade-in">Works</div>
+      <div class="works-grid" id="index-works"></div>
+      <a href="works.html" class="see-all fade-in" id="works-see-all"></a>
     </div>
   </section>
 
@@ -168,7 +168,8 @@
       }
       var list = document.getElementById('index-essays');
       list.replaceChildren();
-      for (var i = 0; i < window.ESSAYS_DATA.length; i++) {
+      var maxEssays = Math.min(window.ESSAYS_DATA.length, 3);
+      for (var i = 0; i < maxEssays; i++) {
         var essay = window.ESSAYS_DATA[i];
         var a = document.createElement('a');
         a.href = 'writing-post.html?slug=' + essay.slug;
@@ -247,9 +248,15 @@
       var weightedTotal = 0;
       for (var i = 0; i < UNICODE_RANGES.length; i++) weightedTotal += UNICODE_RANGES[i].weight;
 
-      /* Step 7: ■ 精煉 — 降至 0.07，混入 □ (3:1) */
+      /* Step 7: ■ 精煉 — 僅實心方塊 */
       var SQUARE_CHANCE = 0.07;
-      var SQUARES = ['\u25A0', '\u25A0', '\u25A0', '\u25A1'];
+      var SQUARES = ['\u25A0'];
+
+      /* 墨色色盤 — flash 帶色用 */
+      var INK_COLORS = [
+        'var(--ink-blue)', 'var(--ink-brown)', 'var(--ink-purple)',
+        'var(--ink-red)', 'var(--ink-teal)'
+      ];
 
       function pickWeightedRange() {
         var r = Math.random() * weightedTotal;
@@ -282,7 +289,7 @@
         var cy = cx;
         var dist = Math.sqrt(Math.pow(row - cy, 2) + Math.pow(col - cx, 2)) / cx;
         var factor = 1 - Math.min(dist, 1) * 0.4;
-        return (0.06 + Math.random() * 0.06) * factor;
+        return (0.12 + Math.random() * 0.08) * factor;
       }
 
       var field = document.getElementById('glyph-field');
@@ -317,7 +324,7 @@
           var baseInterval = 60 + Math.random() * 20;
           setTimeout(function() {
             span.style.transition = 'none';
-            span.style.opacity = '0.20';
+            span.style.opacity = '0.25';
             var done = 0;
             function doFlip() {
               done++;
@@ -390,12 +397,14 @@
               var baseInterval = 60 + Math.random() * 20;
               var stagger = Math.random() * 350;
 
-              /* Step 4: ~15% 機率亮閃 — 墨跡反光 */
+              /* Step 4: ~15% 機率亮閃 — 墨跡反光（帶主題色） */
               var isFlash = Math.random() < 0.15;
-              var flashOp = isFlash ? 0.35 : 0.22;
+              var flashOp = isFlash ? 0.45 : 0.22;
+              var flashColor = isFlash ? INK_COLORS[Math.floor(Math.random() * INK_COLORS.length)] : '';
 
               setTimeout(function() {
                 span.style.opacity = String(flashOp);
+                if (flashColor) span.style.color = flashColor;
 
                 /* Step 5: 亮閃漣漪 — 等高線式區域擴散 */
                 if (isFlash) {
@@ -414,16 +423,18 @@
                       var boost = 0.15 * (1 - dist / (rippleRadius + 0.5));
                       var nBase = cellOpacity(nr, nc, cols);
                       var rippleDelay = Math.floor(dist * 80 + Math.random() * 40);
-                      (function(s, op, base) {
+                      (function(s, op, base, clr) {
                         setTimeout(function() {
-                          s.style.transition = 'opacity 0.15s ease-in';
+                          s.style.transition = 'opacity 0.15s ease-in, color 0.15s ease-in';
                           s.style.opacity = String(Math.min(base + op, 0.35));
+                          if (clr) s.style.color = clr;
                           setTimeout(function() {
-                            s.style.transition = 'opacity 0.6s ease-out';
+                            s.style.transition = 'opacity 0.6s ease-out, color 0.4s ease-out';
                             s.style.opacity = String(base);
+                            s.style.color = '';
                           }, 200 + Math.random() * 100);
                         }, rippleDelay);
-                      })(nSpan, boost, nBase);
+                      })(nSpan, boost, nBase, flashColor);
                     }
                   }
                 }
@@ -440,6 +451,7 @@
                   } else {
                     applyCharToSpan(span);
                     span.style.opacity = String(cellOpacity(row, col, cols));
+                    span.style.color = '';
                   }
                 }
                 doFlip();


### PR DESCRIPTION
## Summary

- **Glyph Field 色彩強化**：基礎 opacity 提高、flash 帶 ink 主題色 + ripple 同步帶色、僅保留實心方塊
- **區塊重排**：Tools → Writing → Works，隨筆限 3 篇，首頁專用 padding 縮減
- **行動版 Header**：精簡為 logo + EN + ☰，♡ 和 🌙 收進 hamburger dropdown

Fixes #21

## Test plan

- [ ] 桌面版：glyph field 色彩明顯但不刺眼，flash 帶色自然
- [ ] 桌面版：header 不受影響（♡ EN 🌙 全部可見）
- [ ] 行動版（375px）：header 只顯示 logo + EN + ☰
- [ ] 行動版：展開 hamburger 顯示導航連結 + ♡ 🌙 功能按鈕
- [ ] 深色模式切換正常（兩種主題下色彩協調）
- [ ] 區塊順序：工具 → 隨筆 → 作品
- [ ] 隨筆最多 3 篇 + 閱讀更多連結間距合理

🤖 Generated with [Claude Code](https://claude.com/claude-code)