### PR TITLE
refactor: PR 1 修紅燈 + 拆 card 三變體 (#24)

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,12 +40,12 @@
 
   <div class="gradient-divider"></div>
 
-  <section id="support" class="section support-section">
+  <section id="support" class="section card-static support-section">
     <div class="container">
       <div class="content-narrow">
-        <div class="section-label fade-in"><i class="ph ph-heart"></i> <span data-i18n="support.label">Support</span></div>
-        <p class="fade-in" style="color: var(--text-secondary); margin-bottom: var(--space-lg);" data-i18n="support.desc">如果我的作品或工具對你有幫助，歡迎支持我的創作。</p>
-        <div class="support-grid fade-in">
+        <div class="section-label"><i class="ph ph-heart"></i> <span data-i18n="support.label">Support</span></div>
+        <p style="color: var(--text-secondary); margin-bottom: var(--space-lg);" data-i18n="support.desc">如果我的作品或工具對你有幫助，歡迎支持我的創作。</p>
+        <div class="support-grid">
           <a href="https://p.ecpay.com.tw/120048C" target="_blank" rel="noopener" class="support-card support-card-ecpay">
             <i class="ph ph-credit-card"></i>
             <span data-i18n="support.ecpay">綠界 ECPay</span>
@@ -144,10 +144,6 @@
         }
       }
 
-      container.querySelectorAll('.timeline-year, .timeline-desc').forEach(function(el) {
-        el.classList.add('fade-in');
-      });
-      observeNewFadeIns(container);
       document.documentElement.classList.remove('js-loading');
     }
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -260,14 +260,11 @@ function renderFeaturedProduct() {
   var desc = i18n[tool.featured.descKey] || (typeof tool.desc === 'object' ? (tool.desc[currentLang] || tool.desc.zh) : tool.desc);
   var cta = i18n[tool.featured.ctaKey] || '';
 
-  var existing = slot.querySelector('.product-card');
-  var wasVisible = existing && existing.classList.contains('visible');
-
   var card = document.createElement('a');
   card.href = tool.url;
   card.target = '_blank';
   card.rel = 'noopener';
-  card.className = 'product-card fade-in' + (wasVisible ? ' visible' : '');
+  card.className = 'product-card';
 
   var info = document.createElement('div');
   info.className = 'product-info';
@@ -316,8 +313,6 @@ function renderFeaturedProduct() {
   card.appendChild(footer);
 
   slot.replaceChildren(card);
-
-  if (!wasVisible) observeNewFadeIns(slot);
 }
 
 // ===== Init =====

--- a/assets/style.css
+++ b/assets/style.css
@@ -190,14 +190,89 @@ body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height
 .support-card-paypal .ph { color: color-mix(in srgb, #0070BA 60%, var(--text-secondary)); }
 .header-btn-support:hover { color: var(--ink-red); }
 
-/* ===== 11. Shared Card Patterns ===== */
-.product-card, .tool-card, .work-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 8px; padding: var(--space-lg); text-decoration: none; color: var(--text); display: flex; flex-direction: column; transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s; position: relative; overflow: hidden; }
-.product-card::before, .tool-card::before, .work-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: linear-gradient(90deg, var(--gradient-brand)); opacity: 0; transition: opacity 0.3s; }
-.product-card:hover, .tool-card:hover, .work-card:hover { transform: translateY(-4px); border-color: var(--border); box-shadow: var(--shadow-hover); }
-.product-card:hover::before, .tool-card:hover::before, .work-card:hover::before { opacity: 1; }
-.product-footer, .tool-card-footer, .work-card-footer { display: flex; align-items: center; justify-content: space-between; margin-top: var(--space-sm); font-family: var(--font-mono); font-size: 0.7rem; color: var(--text-secondary); }
-.product-link, .tool-card-link, .work-card-link { display: flex; align-items: center; gap: 0.3em; opacity: 0; transform: translateX(-6px); transition: opacity 0.3s, transform 0.3s; }
-.product-card:hover .product-link, .tool-card:hover .tool-card-link, .work-card:hover .work-card-link { opacity: 1; transform: translateX(0); }
+/* ===== 11. Card 三變體（component-patterns §4 規範） ===== */
+
+/* 4a. .card-static — 純靜態容器：newsletter、support、article-nav 等 */
+.card-static {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+}
+
+/* 4b. .card.interactive — 整張為 <a>；translateY(-2px) 無 shadow、無頂條、無箭頭滑入 */
+.card.interactive {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: var(--space-lg);
+  text-decoration: none;
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s, border-color 0.3s;
+  position: relative;
+  overflow: hidden;
+}
+.card.interactive:hover {
+  transform: translateY(-2px);
+  border-color: var(--border);
+}
+
+/* 4c. .card-feature — 漸層頂條永遠顯示，無 hover 動畫 */
+.card-feature {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: var(--space-lg);
+  position: relative;
+  overflow: hidden;
+}
+.card-feature::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--gradient-brand));
+  opacity: 1;
+}
+
+/* Legacy aliases — 對齊 .card.interactive 規範（無頂條淡入、無箭頭滑入、無 shadow lift） */
+.product-card, .tool-card, .work-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: var(--space-lg);
+  text-decoration: none;
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s, border-color 0.3s;
+  position: relative;
+  overflow: hidden;
+}
+.product-card:hover, .tool-card:hover, .work-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border);
+}
+.product-footer, .tool-card-footer, .work-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+.product-link, .tool-card-link, .work-card-link {
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
+}
 
 /* ===== 12. Tools — Product Card ===== */
 .product-info h3 { font-family: var(--font-serif); font-size: 1.3rem; font-weight: 500; margin-bottom: 0.25rem; }
@@ -230,8 +305,7 @@ body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height
 .work-card h3 { font-family: var(--font-serif); font-size: 1.15rem; font-weight: 500; letter-spacing: 0.03em; flex: 1; }
 .work-card p { font-size: 0.9rem; color: var(--text-secondary); line-height: 1.7; }
 .work-card-tag { font-family: var(--font-mono); font-size: 0.7rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-secondary); margin-bottom: var(--space-xs); }
-.work-card-arrow { position: absolute; bottom: var(--space-md); right: var(--space-md); color: var(--text-secondary); opacity: 0; transform: translateX(-8px); transition: opacity 0.3s ease, transform 0.3s ease; font-size: 1.1rem; }
-.work-card:hover .work-card-arrow { opacity: 1; transform: translateX(0); }
+.work-card-arrow { position: absolute; bottom: var(--space-md); right: var(--space-md); color: var(--text-secondary); font-size: 1.1rem; }
 
 .category-header { grid-column: 1 / -1; font-family: var(--font-mono); font-size: 0.75rem; letter-spacing: 0.15em; text-transform: uppercase; color: var(--text-secondary); display: flex; align-items: center; gap: 0.75rem; padding: var(--space-sm) 0; margin-top: var(--space-md); }
 .category-header:first-child { margin-top: 0; }
@@ -280,7 +354,7 @@ body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height
 [data-lang="en"] .article-body-lang-notice { display: block; }
 [data-lang="en"] .article-body { display: none; }
 
-/* Article body typography — sans-serif for long-form readability; fluid font-size anchored ~18px */
+/* Article body typography — 使用者實機驗證：CJK 長文 sans (黑體) 比 serif 更易讀，此處例外 Brand DNA #2；fluid clamp ~18px */
 .article-body { max-width: 42rem; margin: 0 auto; padding: 0 var(--space-md) var(--space-2xl); font-family: var(--font-sans); font-size: clamp(1.09375rem, 1rem + 0.3vw, 1.1875rem); line-height: 1.75; }
 .article-body h2 { font-family: var(--font-serif); font-size: 1.5rem; font-weight: 600; letter-spacing: 0.03em; margin-top: var(--space-xl); margin-bottom: var(--space-sm); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border-light); }
 .article-body h3 { font-family: var(--font-serif); font-size: 1.2rem; font-weight: 500; margin-top: var(--space-lg); margin-bottom: var(--space-xs); }
@@ -311,12 +385,12 @@ body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height
 .article-author-name { font-family: var(--font-serif); font-size: 1rem; font-weight: 500; }
 .article-author-desc { font-size: 0.85rem; color: var(--text-secondary); }
 
-/* Article navigation */
-.article-nav { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-md); padding-bottom: var(--space-2xl); }
-.article-nav-item { text-decoration: none; color: var(--text); padding: var(--space-md); border: 1px solid var(--border-light); border-radius: 8px; transition: border-color 0.2s, transform 0.2s; }
-.article-nav-item:hover { border-color: var(--border); transform: translateY(-2px); }
+/* Article navigation — editorial list（per Recipe 5：文末純文字列表，不用 card grid） */
+.article-nav { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-lg); padding: var(--space-lg) 0 var(--space-2xl); border-top: 1px solid var(--border-light); }
+.article-nav-item { text-decoration: none; color: var(--text); display: block; }
+.article-nav-item:hover .article-nav-title { text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 0.2em; }
 .article-nav-label { font-family: var(--font-mono); font-size: 0.7rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-secondary); display: flex; align-items: center; gap: 0.3em; margin-bottom: var(--space-xs); }
-.article-nav-title { font-family: var(--font-serif); font-size: 0.95rem; font-weight: 500; }
+.article-nav-title { font-family: var(--font-serif); font-size: 1rem; font-weight: 500; line-height: 1.5; }
 .article-nav-next { text-align: right; }
 .article-nav-next .article-nav-label { justify-content: flex-end; }
 

--- a/index.html
+++ b/index.html
@@ -40,8 +40,8 @@
   <section class="section">
     <div class="container">
       <div class="section-label fade-in">Tools</div>
-      <div id="featured-product" class="fade-in"></div>
-      <a href="tools.html" class="see-all fade-in" id="tools-see-all"></a>
+      <div id="featured-product"></div>
+      <a href="tools.html" class="see-all" id="tools-see-all"></a>
     </div>
   </section>
 
@@ -52,7 +52,7 @@
     <div class="container">
       <div class="section-label fade-in">Writing</div>
       <div class="essays-list" id="index-essays"></div>
-      <a href="writing.html" class="see-all fade-in" id="writing-see-all"></a>
+      <a href="writing.html" class="see-all" id="writing-see-all"></a>
     </div>
   </section>
 
@@ -63,7 +63,7 @@
     <div class="container">
       <div class="section-label fade-in">Works</div>
       <div class="works-grid" id="index-works"></div>
-      <a href="works.html" class="see-all fade-in" id="works-see-all"></a>
+      <a href="works.html" class="see-all" id="works-see-all"></a>
     </div>
   </section>
 
@@ -71,7 +71,7 @@
 
   <section class="section">
     <div class="container">
-      <div class="newsletter-section fade-in">
+      <div class="card-feature newsletter-section fade-in">
         <h2 class="newsletter-title"><i class="ph ph-envelope-simple"></i> <span data-i18n="newsletter.title">設計筆記</span></h2>
         <p class="newsletter-desc" data-i18n="newsletter.desc">不定期分享字型設計思考、工具開發心得，以及創作過程中的發現。</p>
         <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/erikyin" method="post" target="_blank">
@@ -116,7 +116,7 @@
         var a = document.createElement('a');
         a.href = w.url;
         if (w.url.indexOf('http') === 0) { a.target = '_blank'; a.rel = 'noopener'; }
-        a.className = 'work-card fade-in';
+        a.className = 'work-card';
 
         var tag = document.createElement('div');
         tag.className = 'work-card-tag';
@@ -159,7 +159,7 @@
         var essay = window.ESSAYS_DATA[i];
         var a = document.createElement('a');
         a.href = 'writing-post.html?slug=' + essay.slug;
-        a.className = 'essay-item fade-in';
+        a.className = 'essay-item';
 
         var dateSpan = document.createElement('span');
         dateSpan.className = 'essay-date';

--- a/tools.html
+++ b/tools.html
@@ -28,7 +28,7 @@
   <section class="section">
     <div class="container">
       <div class="section-label fade-in"><i class="ph ph-star"></i> <span data-i18n="tools.section.featured">Featured</span></div>
-      <div id="featured-product" class="fade-in"></div>
+      <div id="featured-product"></div>
     </div>
   </section>
 
@@ -39,7 +39,7 @@
     <div class="container">
       <div class="section-label fade-in"><i class="ph ph-app-window"></i> <span data-i18n="tools.section.apps">Apps</span></div>
       <div class="tools-grid">
-        <a href="https://erikyin.net/panda-zhuyin/" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://erikyin.net/panda-zhuyin/" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-keyboard tool-card-icon"></i><span class="tool-card-tag">iOS App</span></div>
           <h3 data-i18n="tools.panda.title">胖打注音</h3>
           <p data-i18n="tools.panda.desc">為粗手指打造的注音輸入法。Layered-Expand 12 鍵佈局、注音語音學分組、候選區情境變體。</p>
@@ -54,39 +54,39 @@
   <!-- Plugins -->
   <section class="section">
     <div class="container">
-      <div class="section-label fade-in"><i class="ph ph-puzzle-piece"></i> <span data-i18n="tools.section.plugins">Plugins</span></div>
+      <div class="section-label"><i class="ph ph-puzzle-piece"></i> <span data-i18n="tools.section.plugins">Plugins</span></div>
       <div class="tools-grid">
-        <a href="https://github.com/yintzuyuan/HanziIDSComponentExplorer" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/HanziIDSComponentExplorer" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-tree-structure tool-card-icon"></i><span class="tool-card-tag">Open Source</span></div>
           <h3 data-i18n="tools.hanzi.title">漢字部件探索器</h3>
           <p data-i18n="tools.hanzi.desc">利用 IDS（表意文字描述序列）探索漢字部件組成的 Glyphs 外掛。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://erikyin.net/NineBoxView-Pro/" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://erikyin.net/NineBoxView-Pro/" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-grid-nine tool-card-icon"></i><span class="tool-card-tag">Glyphs Plugin</span></div>
           <h3>NineBoxView Pro</h3>
           <p data-i18n="tools.nbv.desc">Glyphs 字型編輯器的預覽工具。在可自訂的網格中並排比較字符，直接在畫布上即時呈現。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://github.com/yintzuyuan/zoom-to-selection" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/zoom-to-selection" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-magnifying-glass-plus tool-card-icon"></i><span class="tool-card-tag">Open Source</span></div>
           <h3 data-i18n="tools.zoom.title">拉至選取範圍</h3>
           <p data-i18n="tools.zoom.desc">快速縮放至選取的節點或錨點，提升編輯效率。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://github.com/yintzuyuan/ShowBopomofo" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/ShowBopomofo" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-translate tool-card-icon"></i><span class="tool-card-tag">Open Source</span></div>
           <h3 data-i18n="tools.phonetics.title">顯示漢語發音</h3>
           <p data-i18n="tools.phonetics.desc">在 Glyphs 編輯器中即時顯示漢字的注音或拼音。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://github.com/yintzuyuan/Bopomo_Ligasystem" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/Bopomo_Ligasystem" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-link tool-card-icon"></i><span class="tool-card-tag">Open Source</span></div>
           <h3 data-i18n="tools.bopo.title">注音合字架構系統</h3>
           <p data-i18n="tools.bopo.desc">Glyphs 注音連字（ligature）的標準化製作範本。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://github.com/yintzuyuan/NineBoxView" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/NineBoxView" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-grid-nine tool-card-icon"></i><span class="tool-card-tag">Open Source</span></div>
           <h3>NineBoxView</h3>
           <p data-i18n="tools.nbv-free.desc">免費版九宮格預覽外掛，Glyphs 社群最受歡迎的工具之一。</p>
@@ -101,33 +101,33 @@
   <!-- Scripts & Resources -->
   <section class="section">
     <div class="container">
-      <div class="section-label fade-in"><i class="ph ph-code"></i> <span data-i18n="tools.section.scripts">Scripts & Resources</span></div>
+      <div class="section-label"><i class="ph ph-code"></i> <span data-i18n="tools.section.scripts">Scripts & Resources</span></div>
       <div class="tools-grid">
-        <a href="https://github.com/yintzuyuan/ScriptMate" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/ScriptMate" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-code tool-card-icon"></i><span class="tool-card-tag">Glyphs Plugin</span></div>
           <h3 data-i18n="tools.scriptmate.title">ScriptMate</h3>
           <p data-i18n="tools.scriptmate.desc">Glyphs 3 的 AI 腳本工作台，整合智慧輔助的腳本開發環境。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://erikyin.net/glyphs-info-mcp" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://erikyin.net/glyphs-info-mcp" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-plugs-connected tool-card-icon"></i><span class="tool-card-tag">Developer Tool</span></div>
           <h3 data-i18n="tools.mcp.title">Glyphs Info MCP</h3>
           <p data-i18n="tools.mcp.desc">整合 Glyphs 手冊與 API 文件的 MCP 伺服器，為 AI 助手提供即時查詢。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://github.com/yintzuyuan/GlyphsApp-Stubs_zh-tw" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/GlyphsApp-Stubs_zh-tw" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-file-py tool-card-icon"></i><span class="tool-card-tag">Developer Tool</span></div>
           <h3 data-i18n="tools.stubs.title">Glyphs 架構字典檔</h3>
           <p data-i18n="tools.stubs.desc">Python 型別提示檔，為 Glyphs 腳本開發提供 IDE 自動補全。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://github.com/yintzuyuan/Glyphs_Scripts" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://github.com/yintzuyuan/Glyphs_Scripts" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-terminal-window tool-card-icon"></i><span class="tool-card-tag">Python</span></div>
           <h3 data-i18n="tools.scripts.title">Glyphs 腳本集</h3>
           <p data-i18n="tools.scripts.desc">實用的 Glyphs 自動化腳本，涵蓋字符管理、路徑處理等。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://chatgpt.com/g/g-6VY8cYFqx-glyphs-jiao-ben-zhu-shou" target="_blank" rel="noopener" class="tool-card fade-in">
+        <a href="https://chatgpt.com/g/g-6VY8cYFqx-glyphs-jiao-ben-zhu-shou" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-robot tool-card-icon"></i><span class="tool-card-tag">AI Assistant</span></div>
           <h3 data-i18n="tools.gpts.title">Glyphs 腳本助手 GPTs</h3>
           <p data-i18n="tools.gpts.desc">基於 ChatGPT 的 Glyphs 腳本撰寫助手。</p>

--- a/works.html
+++ b/works.html
@@ -23,7 +23,7 @@
       <p class="page-header-desc" data-i18n="works.page.desc">字型設計、翻譯貢獻、開源專案與視覺藝術。開發工具請見工具頁。</p>
     </div>
 
-    <div class="filter-tabs fade-in" id="filter-tabs"></div>
+    <div class="filter-tabs" id="filter-tabs"></div>
     <div class="works-grid" id="works-grid"></div>
   </div>
 
@@ -64,7 +64,7 @@
       a.href = project.url;
       a.target = '_blank';
       a.rel = 'noopener';
-      a.className = 'work-card fade-in';
+      a.className = 'work-card';
 
       var catDiv = document.createElement('div');
       catDiv.className = 'work-card-category';

--- a/writing-post.html
+++ b/writing-post.html
@@ -7,7 +7,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Noto+Serif+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Noto+Sans+TC:wght@400&family=Noto+Serif+TC:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <script defer src="https://unpkg.com/@phosphor-icons/web@2.1.1"></script>
   <script>/* theme flash prevention + FOUC prevention */(function(){var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);else if(matchMedia('(prefers-color-scheme:dark)').matches)document.documentElement.setAttribute('data-theme','dark');document.documentElement.classList.add('js-loading')})()</script>
   <link rel="stylesheet" href="assets/style.css">
@@ -40,14 +40,14 @@
 
   <div class="article-end">
     <div class="article-divider"></div>
-    <div class="article-author fade-in">
+    <div class="article-author">
       <img src="assets/images/profile.png" alt="殷慈遠" class="article-author-photo">
       <div>
         <div class="article-author-name" data-i18n="author.name">殷慈遠</div>
         <div class="article-author-desc" data-i18n="author.desc">字型設計師、工具開發者。用工程思維做字，用設計思維寫程式。</div>
       </div>
     </div>
-    <div class="newsletter-section fade-in">
+    <div class="card-feature newsletter-section">
       <h2 class="newsletter-title"><i class="ph ph-envelope-simple"></i> <span data-i18n="newsletter.title">設計筆記</span></h2>
       <p class="newsletter-desc" data-i18n="newsletter.desc">不定期分享字型設計思考、工具開發心得，以及創作過程中的發現。</p>
       <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/erikyin" method="post" target="_blank">
@@ -57,7 +57,7 @@
       </form>
       <p class="newsletter-privacy" data-i18n="newsletter.privacy">不會寄垃圾信，隨時可以退訂。</p>
     </div>
-    <nav class="article-nav fade-in" id="article-nav"></nav>
+    <nav class="article-nav" id="article-nav"></nav>
   </div>
 
   <div id="site-footer"></div>
@@ -259,7 +259,7 @@
         card.href = tool.url;
         card.target = '_blank';
         card.rel = 'noopener noreferrer';
-        card.className = 'tool-card fade-in';
+        card.className = 'tool-card';
 
         var header = document.createElement('div');
         header.className = 'tool-card-header';
@@ -295,9 +295,6 @@
       }
 
       container.replaceChildren(label, grid);
-
-      // 動態插入的 fade-in 元素交給 IntersectionObserver
-      observeNewFadeIns(container);
     }
 
     loadArticle();

--- a/writing.html
+++ b/writing.html
@@ -29,7 +29,7 @@
 
     <div class="essays-list" id="essays-list"></div>
 
-    <div class="newsletter-section fade-in">
+    <div class="card-feature newsletter-section">
       <h2 class="newsletter-title"><i class="ph ph-envelope-simple"></i> <span data-i18n="newsletter.title">設計筆記</span></h2>
       <p class="newsletter-desc" data-i18n="newsletter.desc">不定期分享字型設計思考、工具開發心得，以及創作過程中的發現。</p>
       <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/erikyin" method="post" target="_blank">
@@ -53,7 +53,6 @@
       container.replaceChildren();
       if (!window.ESSAYS_DATA || window.ESSAYS_DATA.length === 0) {
         var emptyMsg = document.createElement('p');
-        emptyMsg.className = 'fade-in';
         emptyMsg.style.color = 'var(--text-secondary)';
         emptyMsg.textContent = currentLang === 'en' ? 'No articles yet. Stay tuned.' : '文章準備中。';
         container.appendChild(emptyMsg);
@@ -64,7 +63,7 @@
         var essay = window.ESSAYS_DATA[i];
         var a = document.createElement('a');
         a.href = 'writing-post.html?slug=' + essay.slug;
-        a.className = 'essay-item fade-in';
+        a.className = 'essay-item';
 
         var dateSpan = document.createElement('span');
         dateSpan.className = 'essay-date';


### PR DESCRIPTION
## Summary

對齊 personal-brand:brand-design-guide 規範，修正 6 個 anti-AI 視覺訊號 + 拆分 card 三變體。Issue #24 升級計畫 PR 1/4。

## 紅燈修正

- **R1** 漸層頂條 hover 淡入 → 永遠顯示（`.card-feature`）或永遠不顯示（`.card.interactive`），禁止 hover trigger
- **R2** 箭頭 hover 滑入 → 永遠顯示
- **R3** card hover lift translateY(-4px) + shadow-hover → translateY(-2px) 無 shadow
- **R5** article-nav card grid → editorial list（border-top + 純文字 prev/next + underline hover）
- **R6** fade-in 過量 → 每頁 ≤5 個（about 2 / index 5 / tools 3 / works 1 / writing-post 2 / writing 1）

## 維度 2：Card 三變體拆分

CSS 新增 `.card-static` / `.card.interactive` / `.card-feature` 對齊 component-patterns §4 規範。HTML 加語義 marker：
- `newsletter-section` 加 `.card-feature`
- `support-section` 加 `.card-static`

## R4 例外（重要）

`.article-body` 字型維持 `var(--font-sans)` 不變——使用者實機驗證黑體閱讀體驗優於明體（per b71e39d 與 closes #23），這是 Brand DNA #2「字型體系僅含 serif + mono」的合理例外。

決策已存入 `~/.claude/projects/-Users-yintzuyuan-code-personal-yintzuyuan-github-io/memory/feedback-article-body-uses-sans.md` 跨 session 保留，避免未來 PR 再次誤改。

## Test plan

- [ ] 各頁面亮/暗模式視覺檢查（index、about、writing、writing-post、works、tools、privacy、terms）
- [ ] Mobile 375 / Tablet 768 / Desktop 1024+ 三斷點
- [ ] anti-AI checklist 五題終檢：
  - [ ] 拿掉所有 hover 動畫仍站得住
  - [ ] 拿掉所有 card border 仍分辨層級
  - [ ] 5 秒內找到最重要東西
  - [ ] 氣質接近字型工作室同行
  - [ ] 說故事而非列功能

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)