### PR TITLE
refactor: PR 3 黃燈清理 + section-rule + 暗模式精緻化 (#24)

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -131,7 +131,8 @@ body {
 
 /* ===== 6. Paper Texture ===== */
 body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 9999; opacity: 0.025; background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E"); background-repeat: repeat; background-size: 256px 256px; }
-[data-theme="dark"] body::after { opacity: 0.04; }
+[data-theme="dark"] body::after { opacity: 0.055; }
+.section-rule { border: none; border-top: 1px solid var(--border-light); margin: var(--space-2xl) 0; width: 100%; }
 
 /* ===== 7. Index — Hero ===== */
 .hero { padding: var(--space-2xl) 0; }
@@ -277,7 +278,6 @@ body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height
 /* ===== 12. Tools — Product Card ===== */
 .product-info h3 { font-family: var(--font-serif); font-size: 1.3rem; font-weight: 500; margin-bottom: 0.25rem; }
 .product-badge { display: inline-block; font-family: var(--font-mono); font-size: 0.65rem; letter-spacing: 0.1em; text-transform: uppercase; padding: 0.2em 0.6em; border-radius: 3px; background: linear-gradient(135deg, var(--ink-brown), var(--ink-blue)); color: #f4f0e8; margin-left: 0.5rem; vertical-align: middle; }
-[data-theme="dark"] .product-badge { color: #e8e2d8; }
 .product-description { font-size: 0.95rem; color: var(--text-secondary); margin-top: var(--space-xs); line-height: 1.8; }
 .product-features { list-style: none; margin-top: var(--space-sm); display: flex; flex-wrap: wrap; gap: 0.5rem; }
 .product-features li { font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-secondary); padding: 0.3em 0.8em; border: 1px solid var(--border); border-radius: 4px; display: flex; align-items: center; gap: 0.4em; }

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     </div>
   </section>
 
-  <div class="gradient-divider"></div>
+  <hr class="section-rule">
 
   <!-- Writing -->
   <section class="section">
@@ -67,7 +67,7 @@
     </div>
   </section>
 
-  <div class="gradient-divider"></div>
+  <hr class="section-rule">
 
   <section class="section">
     <div class="container">


### PR DESCRIPTION
## Summary

Issue #24 brand-design 升級的第三個（最後一個）PR。延續 PR #25（紅燈 + card 三變體）與 PR #26（Hero 不對稱 + Works editorial list），收尾 v3 plan 列出的 3 個剩餘黃燈。

- **Y4 — gradient-divider 節奏調節**：index.html 4 連分隔線改為「漸層、細線、漸層、細線」交錯。第 2、4 個改為 `<hr class="section-rule">`，第 1、3 個保留 `gradient-divider`（跨類別重要轉場）。新增 `.section-rule` utility（`1px solid var(--border-light)` + `margin: var(--space-2xl) 0`），與 `footer-bottom` border-top 視覺語言一致。
- **Y5 — 暗模式紙質紋理**：`[data-theme="dark"] body::after` opacity `0.04` → `0.055`。暗模式底色 `#1a1816` + 中性灰 noise pattern 對比較弱、紋理近乎消失；`0.055` 仍遠低於「明顯顆粒」門檻，恢復「紙感不缺席」。
- **Y10 — 暗模式 product-badge contrast**：實機量測暗模式 `#e8e2d8` vs `gradient(ink-brown, ink-blue)` contrast **2.09–2.25**、亮模式 `#f4f0e8` 為 **2.37–2.55**，**兩者皆未達 AA 3:1**。刪除 `[data-theme="dark"] .product-badge color` override，亮/暗模式統一 `#f4f0e8`，暗模式 contrast 提升至與亮模式同等級。底層 gradient 飽和度限制 contrast 上限 ~2.8（純白文字也達不到 3:1），要達 AA 須調整 `--ink-brown` / `--ink-blue` 飽和度，屬品牌色決定**列為 follow-up**。

範圍：`style.css` 4 ++/--、`index.html` 4 ++/--，無 JS / data 改動。

## Test plan

實機驗證（local server + claude-in-chrome）：

- [x] index.html 4 個分隔線順序：DIV.gradient-divider, HR.section-rule, DIV.gradient-divider, HR.section-rule（交錯模式正確）
- [x] `.section-rule` CSS 規則存在；暗模式 `border-top-color: rgb(46, 42, 38)` (= `#2e2a26` = `--border-light` 暗模式值)
- [x] `.section-rule` `margin-top: 96px` (= `6rem` = `var(--space-2xl)`)
- [x] 暗模式 `body::after` opacity 量測為 `0.055`
- [x] 亮模式 `.product-badge` color `rgb(244, 240, 232)` (= `#f4f0e8`)
- [x] 暗模式 `.product-badge` color 同樣為 `rgb(244, 240, 232)`（dark override 已刪除）
- [x] 亮模式 / 暗模式 contrast 量測差距縮小至 ~0（之前 ~0.3）

## Anti-AI checklist 五題（不退步）

無新增 hover 動畫、無新 card box、無新裝飾；divider 改為 hr 反而更語義化（screen reader 友善）。

## 後續（不屬本 PR）

- product-badge contrast 達 AA 需動 `--ink-brown` / `--ink-blue` 飽和度，是品牌色決定，另開 issue
- Plugin cache `personal-brand/1.1.0/` 同步（在 `claude-code-plugins` 處理 version bump）

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)