### PR TITLE
refactor: tools 頁新增 Glyphs Reference（取代展示中的 Glyphs Info MCP）

### DIFF
--- a/data/tools.js
+++ b/data/tools.js
@@ -163,5 +163,15 @@ window.TOOLS_DATA = {
     url: 'https://erikyin.net/glyphs-info-mcp',
     icon: 'ph-plugs-connected',
     tag: 'Developer Tool'
+  },
+  'glyphs-reference': {
+    title: 'Glyphs Reference',
+    desc: {
+      zh: 'Glyphs.app API 與文件查詢的 Claude Code 技能組，10 個 skills 加 1 個 meta-dispatcher agent，取代舊版 MCP 伺服器。',
+      en: 'A skills-based Glyphs.app API reference for Claude Code: 10 skills plus 1 meta-dispatcher agent. Replaces the legacy MCP server.'
+    },
+    url: 'https://erikyin.net/glyphs-reference',
+    icon: 'ph-stack',
+    tag: 'Claude Code Plugin'
   }
 };

--- a/data/ui.js
+++ b/data/ui.js
@@ -67,6 +67,8 @@ window.UI_DATA = {
     'tools.scriptmate.desc': 'Glyphs 3 的 AI 腳本工作台，整合智慧輔助的腳本開發環境。',
     'tools.mcp.title': 'Glyphs Info MCP',
     'tools.mcp.desc': '整合 Glyphs 手冊與 API 文件的 MCP 伺服器，為 AI 助手提供即時查詢。',
+    'tools.glyphsref.title': 'Glyphs Reference',
+    'tools.glyphsref.desc': 'Glyphs.app API 與文件查詢的 Claude Code 技能組，10 個 skills 加 1 個 meta-dispatcher agent，取代舊版 MCP 伺服器。',
 
     // Works
     'works.page.title': '作品集',
@@ -152,6 +154,8 @@ window.UI_DATA = {
     'tools.scriptmate.desc': 'An AI-powered scripting workbench for Glyphs 3 with intelligent assistance.',
     'tools.mcp.title': 'Glyphs Info MCP',
     'tools.mcp.desc': 'An MCP server integrating Glyphs handbook and API docs for real-time AI assistant queries.',
+    'tools.glyphsref.title': 'Glyphs Reference',
+    'tools.glyphsref.desc': 'A skills-based Glyphs.app API reference for Claude Code: 10 skills plus 1 meta-dispatcher agent. Replaces the legacy MCP server.',
 
     'works.page.title': 'Works',
     'works.page.desc': 'Type design, translations, open source projects, and visual art. For dev tools, see the Tools page.',

--- a/tools.html
+++ b/tools.html
@@ -109,11 +109,11 @@
           <p data-i18n="tools.scriptmate.desc">Glyphs 3 的 AI 腳本工作台，整合智慧輔助的腳本開發環境。</p>
           <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
-        <a href="https://erikyin.net/glyphs-info-mcp" target="_blank" rel="noopener" class="tool-card">
-          <div class="tool-card-header"><i class="ph ph-plugs-connected tool-card-icon"></i><span class="tool-card-tag">Developer Tool</span></div>
-          <h3 data-i18n="tools.mcp.title">Glyphs Info MCP</h3>
-          <p data-i18n="tools.mcp.desc">整合 Glyphs 手冊與 API 文件的 MCP 伺服器，為 AI 助手提供即時查詢。</p>
-          <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-github-logo"></i> <i class="ph ph-arrow-right"></i></span></div>
+        <a href="https://erikyin.net/glyphs-reference" target="_blank" rel="noopener" class="tool-card">
+          <div class="tool-card-header"><i class="ph ph-stack tool-card-icon"></i><span class="tool-card-tag">Claude Code Plugin</span></div>
+          <h3 data-i18n="tools.glyphsref.title">Glyphs Reference</h3>
+          <p data-i18n="tools.glyphsref.desc">Glyphs.app API 與文件查詢的 Claude Code 技能組，10 個 skills 加 1 個 meta-dispatcher agent，取代舊版 MCP 伺服器。</p>
+          <div class="tool-card-footer"><span></span><span class="tool-card-link"><i class="ph ph-arrow-square-out"></i> <i class="ph ph-arrow-right"></i></span></div>
         </a>
         <a href="https://github.com/yintzuyuan/GlyphsApp-Stubs_zh-tw" target="_blank" rel="noopener" class="tool-card">
           <div class="tool-card-header"><i class="ph ph-file-py tool-card-icon"></i><span class="tool-card-tag">Developer Tool</span></div>


### PR DESCRIPTION
## Summary

舊版 \`glyphs-info-mcp\`（MCP 伺服器架構）已退役，新版 \`glyphs-reference\` 是 Claude Code 的 skills-based 插件（10 skills + 1 meta-dispatcher agent），取代舊 MCP 伺服器負責 Glyphs.app API 與文件查詢。

**實作策略：data 層保留 + UI 層替換**

| 層 | glyphs-info-mcp | glyphs-reference |
|----|----|----|
| \`data/tools.js\` | ✓ 保留 entry（給舊文章字卡 lookup） | ✓ 新增 entry |
| \`data/ui.js\` i18n | ✓ 保留 \`tools.mcp.*\` 中英 keys | ✓ 新增 \`tools.glyphsref.*\` 中英 keys |
| \`tools.html\` 卡片 | ✗ 移除 | ✓ 新增 |

## 為何保留舊 entry

舊文章 \`content/writing/translating-glyphs-for-ai.md\`（2025-12-30 發表）frontmatter \`tools: [glyphs-info-mcp]\`，文末 \`article-tools\` 字卡邏輯（\`writing-post.html:235 renderArticleTools\`）透過 \`window.TOOLS_DATA[slug]\` lookup 渲染。

若完全移除舊 entry：
- \`if (!tool) continue\` graceful skip → grid 為空
- 但 \`container.replaceChildren(label, grid)\` 在 line 297 是**無條件**渲染 label
- 結果：用戶看到「Tools mentioned in this article」section-label + 空白 grid

保留 data 層 entry 讓舊文章字卡仍正常顯示 \`Glyphs Info MCP\`，作為 2025-12-30 時點的歷史準確紀錄。

## 新工具 metadata

| 欄位 | 值 |
|------|---|
| slug | \`glyphs-reference\` |
| title | \`Glyphs Reference\` |
| URL | \`https://erikyin.net/glyphs-reference\` |
| icon | \`ph-stack\`（skills 疊層象徵） |
| tag | \`Claude Code Plugin\` |
| desc (zh) | Glyphs.app API 與文件查詢的 Claude Code 技能組，10 個 skills 加 1 個 meta-dispatcher agent，取代舊版 MCP 伺服器。 |
| desc (en) | A skills-based Glyphs.app API reference for Claude Code: 10 skills plus 1 meta-dispatcher agent. Replaces the legacy MCP server. |

## 驗證（claude-in-chrome 本地）

- [x] tools.html: 12 cards 渲染，hasGlyphsRef=true, hasGlyphsInfoMCPVisible=false
- [x] 新卡 href / icon / tag / title 全對
- [x] 舊文章 \`translating-glyphs-for-ai\` article-tools 顯示 1 card \`Glyphs Info MCP\`，指向 \`erikyin.net/glyphs-info-mcp\`
- [x] 中英 i18n keys 都已加

## 不在本 PR 範圍

- 舊文章 frontmatter 與內文 inline 引用維持不動（per 使用者指示「不動舊文章」）
- 新文章介紹 \`glyphs-reference\` 為另外的 work item
- \`data/tools.js\` 中 \`glyphs-info-mcp\` entry 標記為「archive」或「deprecated」標籤（如果之後 schema 演進加 \`archived\` field 再處理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)