### PR TITLE
fix: 移除 .section-rule 多餘 margin 修分隔線節奏不對稱

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -132,7 +132,7 @@ body {
 /* ===== 6. Paper Texture ===== */
 body::after { content: ''; position: fixed; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 9999; opacity: 0.025; background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E"); background-repeat: repeat; background-size: 256px 256px; }
 [data-theme="dark"] body::after { opacity: 0.055; }
-.section-rule { border: none; border-top: 1px solid var(--border-light); margin: var(--space-2xl) 0; width: 100%; }
+.section-rule { border: none; border-top: 1px solid var(--border-light); margin: 0; width: 100%; }
 
 /* ===== 7. Index — Hero ===== */
 .hero { padding: var(--space-2xl) 0; }


### PR DESCRIPTION
## Summary

PR #27 設計 \`.section-rule\` 時加了 \`margin: var(--space-2xl) 0\` (96px)，但 \`.section\` 本身已有 \`padding: var(--space-xl) 0\` (64px)。兩者疊加導致 \`section-rule\` 上下空間遠大於 \`gradient-divider\`。

## 量測（修正前）

| Idx | 類型 | 上方間距 | 下方間距 |
|-----|------|--:|--:|
| 0 (Hero → Tools) | gradient-divider | 96px | 64px |
| **1** (Tools → Writing) | **section-rule** | **160px** | **160px** |
| 2 (Writing → Works) | gradient-divider | 64px | 64px |
| **3** (Works → Newsletter) | **section-rule** | **160px** | **160px** |

差異 ~2.5x，視覺上 section-rule 明顯比 gradient-divider 寬鬆。

## 修正

\`\`\`diff
- .section-rule { border: none; border-top: 1px solid var(--border-light); margin: var(--space-2xl) 0; width: 100%; }
+ .section-rule { border: none; border-top: 1px solid var(--border-light); margin: 0; width: 100%; }
\`\`\`

移除 \`.section-rule\` 多餘 margin，依賴 \`.section\` padding 提供間距，與 \`.gradient-divider\` 對稱。

## 量測（修正後）

4 個 divider 全部：
- \`marginTop: 0px\`
- \`marginBottom: 0px\`
- \`gapAbove: 0px\`（緊貼 section 下緣）
- \`gapBelow: 0px\`（緊貼 section 上緣）

實際視覺間距由 section padding 統一提供。

## Root cause

PR #27 plan 階段拍板 \`.section-rule { margin: var(--space-2xl) 0 }\`，未模擬與 \`.section\` padding 的疊加效果。實機量測一秒抓到——本應在 plan 階段先在腦中跑一次 box model。

🤖 Generated with [Claude Code](https://claude.com/claude-code)